### PR TITLE
feat: Add simple front end for local, Minikube, and EC2 environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,15 @@ RUN pip install --no-cache-dir openai==0.27.0 python-dotenv
 
 # Run hello_devops.py when the container launches
 CMD ["python", "hello_devops.py"]
+
+# Build stage for the static front end
+FROM nginx:latest
+
+# Copy static HTML files into Nginx web root
+COPY index.html /usr/share/nginx/html/index.html
+
+# Expose port 80 to the outside world
+EXPOSE 80
+
+# Start Nginx server
+CMD ["nginx", "-g", "daemon off;"]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Front End Testing</title>
+  </head>
+  <body>
+    <h1>Front End for Testing Purposes</h1>
+    <p>This is a simple front end just for testing purposes.</p>
+    <p>
+      Visit my GitHub repository:
+      <a href="https://github.com/cloudquiza/hello_devops_world">GitHub Repo</a>
+    </p>
+  </body>
+</html>

--- a/k8s-manifests/deployment.yaml
+++ b/k8s-manifests/deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
         - name: hello-devops-world
-          image: cloudquiza/hello-devops-world:latest
+          image: cloudquiza/hello-devops-world:nginx
           ports:
             - containerPort: 80

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,8 +41,8 @@ resource "aws_instance" "hello_devops_instance" {
       "sudo yum install -y docker",
       "sudo service docker start",
       "echo '${var.dockerhub_access_token}' | sudo docker login -u cloudquiza --password-stdin",
-      "sudo docker pull cloudquiza/hello-devops-world:latest",
-      "sudo docker run -d -p 80:80 cloudquiza/hello-devops-world:latest"
+      "sudo docker pull cloudquiza/hello-devops-world:nginx",
+      "sudo docker run -d -p 80:80 cloudquiza/hello-devops-world:nginx"
     ]
     connection {
       type        = "ssh"


### PR DESCRIPTION
- Configured a basic HTML front end for testing purposes.
- Front end serves a static message and includes a link to the GitHub repo.
- Integrated front end locally using Python's HTTP server.
- Set up front end on Minikube and EC2 using Docker and Nginx.
- Ensured that the Python script and AI message functionality remains intact.